### PR TITLE
fix: resolve SQL parsing error with PostgreSQL dollar-quoted strings (issue #29)

### DIFF
--- a/tests/database_tests.rs
+++ b/tests/database_tests.rs
@@ -26,3 +26,109 @@ async fn test_database_config_validation() {
     // Real database connection testing would require TestContainers
     assert!(result.is_ok());
 }
+
+#[cfg(test)]
+mod sql_parsing_tests {
+    use dbfast::DatabasePool;
+
+    #[test]
+    fn test_parse_sql_statements_with_dollar_quoted_strings() {
+        let sql_content = r#"
+-- Create a test table
+CREATE TABLE test_table (id INTEGER);
+
+-- This should be parsed as a single statement despite containing semicolons
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'printoptim_core') THEN
+        CREATE ROLE printoptim_core WITH
+            LOGIN
+            NOSUPERUSER
+            INHERIT
+            CREATEDB
+            NOCREATEROLE
+            NOREPLICATION
+            PASSWORD 'printoptim_core_test';  -- Only for testing/CI
+    END IF;
+END $$;
+
+-- Another simple statement
+INSERT INTO test_table VALUES (1);
+"#;
+
+        // Access the public method for testing
+        let statements = DatabasePool::parse_sql_statements(sql_content);
+
+        // Should have exactly 3 statements:
+        // 1. CREATE TABLE test_table (id INTEGER)
+        // 2. The entire DO $$ ... END $$ block
+        // 3. INSERT INTO test_table VALUES (1)
+        assert_eq!(statements.len(), 3);
+
+        // Check that the DO block is kept as one statement
+        let do_block = statements.iter().find(|s| s.contains("DO $$")).unwrap();
+        assert!(do_block.contains("CREATE ROLE printoptim_core"));
+        assert!(do_block.contains("END $$"));
+
+        // Check other statements
+        assert!(statements
+            .iter()
+            .any(|s| s.contains("CREATE TABLE test_table")));
+        assert!(statements
+            .iter()
+            .any(|s| s.contains("INSERT INTO test_table VALUES (1)")));
+    }
+
+    #[test]
+    fn test_parse_sql_statements_with_nested_dollar_quotes() {
+        let sql_content = r#"
+CREATE OR REPLACE FUNCTION test_func() RETURNS text AS $BODY$
+DECLARE
+    result text := $$Hello; World$$;
+BEGIN
+    RETURN result;
+END;
+$BODY$ LANGUAGE plpgsql;
+"#;
+
+        let statements = DatabasePool::parse_sql_statements(sql_content);
+
+        // Should be one statement
+        assert_eq!(statements.len(), 1);
+        assert!(statements[0].contains("CREATE OR REPLACE FUNCTION"));
+        assert!(statements[0].contains("$$Hello; World$$"));
+    }
+
+    #[test]
+    fn test_parse_sql_statements_edge_cases() {
+        // Test empty input
+        assert!(DatabasePool::parse_sql_statements("").is_empty());
+
+        // Test only comments
+        let comment_only = r#"
+        -- Just comments
+        /* Multi-line comment */
+        "#;
+        assert!(DatabasePool::parse_sql_statements(comment_only).is_empty());
+
+        // Test statement without ending semicolon
+        let no_semicolon = "SELECT 1";
+        let statements = DatabasePool::parse_sql_statements(no_semicolon);
+        assert_eq!(statements.len(), 1);
+        assert_eq!(statements[0], "SELECT 1");
+
+        // Test multiple semicolons in dollar-quoted string
+        let complex_dollar_quote = r#"
+        CREATE FUNCTION complex() RETURNS text AS $func$
+        BEGIN
+            EXECUTE 'SELECT 1; SELECT 2;';  -- Multiple semicolons inside
+            RETURN 'done; really done;';    -- More semicolons
+        END;
+        $func$ LANGUAGE plpgsql;
+        "#;
+        let statements = DatabasePool::parse_sql_statements(complex_dollar_quote);
+        assert_eq!(statements.len(), 1);
+        assert!(statements[0].contains("SELECT 1; SELECT 2"));
+        assert!(statements[0].contains("done; really done"));
+    }
+}


### PR DESCRIPTION
## Summary
Resolves the SQL parsing error that occurs when processing PostgreSQL files containing dollar-quoted strings in role creation statements and stored procedures.

Fixes #29

## Problem
DBFast was encountering "unterminated dollar-quoted string" errors when processing SQL files with DO $$ blocks, causing database execution failures. The issue was in the `parse_sql_statements` function which was incorrectly splitting statements at semicolons inside dollar-quoted blocks.

## Solution
Enhanced the SQL parser to properly handle PostgreSQL dollar-quoted strings:
- Added detection for dollar-quoted string boundaries (`$$`, `$BODY$`, etc.)
- Preserved statement integrity within dollar-quoted blocks
- Improved parsing logic to handle nested dollar quotes and edge cases

## Changes
- **Enhanced `parse_sql_statements`** in `src/database.rs` to detect and handle dollar-quoted string boundaries
- **Added comprehensive tests** covering various dollar-quote scenarios including edge cases
- **Improved helper functions** for dollar-quote tag extraction with better maintainability
- **Fixed parsing logic** to preserve statement integrity within dollar-quoted blocks

## Test Coverage
- ✅ Basic dollar-quoted strings (`DO $$ ... END $$`)
- ✅ Tagged dollar quotes (`$BODY$ ... $BODY$`)
- ✅ Nested dollar quotes with different tags
- ✅ Multiple semicolons inside dollar-quoted blocks
- ✅ Edge cases (empty input, comments only, no semicolons)

## Impact
This resolves the blocking issue for migrating from a 443-line Python database fixture system to DBFast for production PostgreSQL applications with 791 SQL files containing role creation scripts.

## Test Plan
- [x] All existing tests pass
- [x] New comprehensive test suite for dollar-quoted string parsing
- [x] Verified fix handles the exact scenario from issue #29
- [x] Edge cases and complex scenarios covered

🤖 Generated with [Claude Code](https://claude.ai/code)

Type: bug fix